### PR TITLE
feature: add match logging and replay

### DIFF
--- a/lib/arena.c
+++ b/lib/arena.c
@@ -5,6 +5,9 @@
  * @date 2026-05-27
  */
 
+#ifndef ARENA_C
+#define ARENA_C
+
 #include "platforms/platform.h"
 
 
@@ -150,3 +153,4 @@ void BShip_Arena_Rollback(BShip_Arena *arena, BShip_ArenaMark mark)
     arena->current = block;
 }
 
+#endif // ARENA_C

--- a/lib/battleshipslib.h
+++ b/lib/battleshipslib.h
@@ -37,7 +37,7 @@
     } while (0)
 
 #define BSHIP_DEFINE_ARRAY_PUSH(array_type, element_type) \
-static inline void array_type##_Push(array_type *array, element_type element) \
+void array_type##_Push(array_type *array, element_type element) \
 { \
     assert(array != NULL); \
     assert(array->buffer != NULL); \
@@ -107,6 +107,14 @@ typedef struct {
     uint32_t capacity;
 } BShip_ShipArray;
 
+typedef uint16_t BShip_CompactShip;
+
+typedef struct {
+    BShip_CompactShip *buffer;
+    uint32_t length;
+    uint32_t capacity;
+} BShip_CompactShipArray;
+
 typedef struct {
     uint8_t row;
     uint8_t column;
@@ -119,10 +127,24 @@ typedef struct {
     uint32_t capacity;
 } BShip_ShotArray;
 
+typedef uint16_t BShip_CompactShot;
+
+typedef struct {
+    BShip_CompactShot *buffer;
+    uint32_t length;
+    uint32_t capacity;
+} BShip_CompactShotArray;
+
 typedef struct {
     uint8_t *buffer;
     uint8_t size;
 } BShip_Board;
+
+typedef struct {
+    uint8_t *buffer;
+    uint32_t length;
+    uint32_t capacity;
+} BShip_Buffer;
 
 typedef struct {
     char *buffer;
@@ -187,11 +209,11 @@ typedef struct {
     union {
         BShip_GameResult ai1_game_result; // NOTE(mattg): Player 2's state can be derived from Player 1's.
         struct {
-            uint32_t ai1_ship_index;
-            uint32_t ai2_ship_index;
-            uint32_t ai1_shot_index;
-            uint32_t ai2_shot_index;
-        } indexes;
+            BShip_CompactShip ai1_ship;
+            BShip_CompactShip ai2_ship;
+            BShip_CompactShot ai1_shot;
+            BShip_CompactShot ai2_shot;
+        } compact;
     } value;
     BShip_EventType type;
 } BShip_Event;
@@ -204,8 +226,6 @@ typedef struct {
 
 typedef struct {
     BShip_Error error;
-    BShip_ShipArray ships;
-    BShip_ShotArray shots;
     char *name;
     char *authors;
     uint32_t ai_name_length;
@@ -248,6 +268,11 @@ BShip_Board BShip_Board_Allocate(BShip_Arena *arena, uint8_t board_size);
 BShip_BoardValue BShip_Board_Get(BShip_Board board, uint8_t row, uint8_t column);
 void BShip_Board_Set(BShip_Board board, uint8_t row, uint8_t column, BShip_BoardValue value);
 
+BShip_CompactShip BShip_CompactShip_From_Ship(BShip_Ship ship);
+BShip_Ship BShip_Ship_From_CompactShip(BShip_CompactShip compact);
+BShip_CompactShot BShip_CompactShot_From_Shot(BShip_Shot shot);
+BShip_Shot BShip_Shot_From_CompactShot(BShip_CompactShot compact);
+
 // void BShip_Contest_Run(char *socket_path, char *ai_paths[], uint32_t ai_paths_length,
 //     uint8_t board_size, uint32_t games_per_match, BShip_ContestAlgorithm algorithm, bool debug);
 
@@ -262,6 +287,11 @@ size_t BShip_Match_CalculateMemorySize(uint8_t board_size, uint32_t games_per_ma
 BShip_MatchData BShip_Match_Run(BShip_Arena *arena, char *socket_path,
     BShip_AIFileData ai1_file_data, BShip_AIFileData ai2_file_data,
     uint8_t board_size, uint32_t games_per_match, bool debug);
+
+void BShip_Match_Log_Store(BShip_MatchData match, char *path);
+
+bool BShip_Match_Log_Load(BShip_Arena *arena, BShip_MatchData *match, char *path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/battleshipslib.h
+++ b/lib/battleshipslib.h
@@ -110,12 +110,6 @@ typedef struct {
 typedef uint16_t BShip_CompactShip;
 
 typedef struct {
-    BShip_CompactShip *buffer;
-    uint32_t length;
-    uint32_t capacity;
-} BShip_CompactShipArray;
-
-typedef struct {
     uint8_t row;
     uint8_t column;
     BShip_BoardValue value;
@@ -128,12 +122,6 @@ typedef struct {
 } BShip_ShotArray;
 
 typedef uint16_t BShip_CompactShot;
-
-typedef struct {
-    BShip_CompactShot *buffer;
-    uint32_t length;
-    uint32_t capacity;
-} BShip_CompactShotArray;
 
 typedef struct {
     uint8_t *buffer;

--- a/lib/game.c
+++ b/lib/game.c
@@ -117,6 +117,7 @@ void ShipLengths_Calculate(BShip_U8Array *array, uint8_t board_size)
         {
             // TODO: randomly decide the ship length.
         }
+        assert(ship_length > 0);
         array->buffer[array->length] = ship_length;
     }
 }

--- a/lib/log.c
+++ b/lib/log.c
@@ -134,7 +134,7 @@ void BShip_Match_Log_Store(BShip_MatchData match, char *path)
 
     BShip_File_Write(path, &buffer);
 
-    free(buffer.buffer);
+    free(json);
     yyjson_mut_doc_free(doc);
 }
 

--- a/lib/log.c
+++ b/lib/log.c
@@ -1,0 +1,416 @@
+/**
+ * @file log.c
+ * @author Matthew Getgen
+ * @brief Battleships message logic
+ * @date 2026-08-03
+ */
+
+#include "vendor/yyjson/src/yyjson.h"
+#include "arena.c"
+
+#define BOARD_SIZE_KEY   "bs"
+#define EVENTS_KEY       "evt"
+#define AI1_KEY          "ai1"
+#define AI2_KEY          "ai2"
+#define AI_NAME_KEY      "ai"
+#define AUTHOR_NAMES_KEY "au"
+#define ERROR_KEY        "err"
+#define ERROR_TYPE_KEY   "ert"
+#define EXIT_STATUS_KEY  "es"
+#define SHIP_KEY         "sp"
+#define SHOT_KEY         "st"
+#define MESSAGE_KEY      "msg"
+
+BSHIP_DEFINE_ARRAY_PUSH(BShip_EventArray, BShip_Event)
+BSHIP_DEFINE_ARRAY_PUSH(BShip_U32Array, uint32_t)
+
+void BShip_AIMatchData_Create(yyjson_mut_doc *doc, yyjson_mut_val *ai_root, BShip_AIMatchData match)
+{
+    yyjson_mut_obj_add_strn(doc, ai_root, AI_NAME_KEY, match.name, match.ai_name_length);
+    yyjson_mut_obj_add_strn(doc, ai_root, AUTHOR_NAMES_KEY, match.authors, match.author_name_length);
+    if (match.error.type != ERROR_SUCCESS)
+    {
+        yyjson_mut_val *err = yyjson_mut_obj_add_obj(doc, ai_root, ERROR_KEY);
+        yyjson_mut_obj_add_uint(doc, err, ERROR_TYPE_KEY, match.error.type);
+        yyjson_mut_obj_add_sint(doc, err, EXIT_STATUS_KEY, match.error.exit_status);
+        switch (match.error.type)
+        {
+        case ERROR_SUCCESS:
+        case ERROR_AI_PATH_ISSUE:
+        case ERROR_PROCESS_FAILED:
+        case ERROR_CONNECTION_FAILED:
+        case ERROR_CONNECTION_TIMEOUT:
+        case ERROR_SEND_FAILED:
+        case ERROR_SEND_TIMEOUT:
+        case ERROR_RECEIVE_FAILED:
+        case ERROR_RECEIVE_TIMEOUT:
+        case ERROR_RECEIVE_EMPTY_MESSAGE:
+            break;
+        case ERROR_MESSAGE_HELLO_INVALID:
+        case ERROR_MESSAGE_SHIPS_PLACED_INVALID:
+        case ERROR_MESSAGE_SHOT_TAKEN_INVALID:
+            yyjson_mut_obj_add_strn(doc, err, MESSAGE_KEY,
+                match.error.value.message.buffer, match.error.value.message.length);
+            break;
+        case ERROR_SHIP_LENGTH_INVALID:
+        case ERROR_SHIP_OFF_BOARD:
+        case ERROR_SHIP_OVERLAP:
+        {
+            yyjson_mut_val *ship = yyjson_mut_obj_add_arr(doc, err, SHIP_KEY);
+            yyjson_mut_arr_add_uint(doc, ship, match.error.value.ship.row);
+            yyjson_mut_arr_add_uint(doc, ship, match.error.value.ship.column);
+            yyjson_mut_arr_add_uint(doc, ship, match.error.value.ship.length);
+            yyjson_mut_arr_add_uint(doc, ship, match.error.value.ship.direction);
+        } break;
+        case ERROR_SHOT_OFF_BOARD:
+        case ERROR_SHOT_DUPLICATE:
+        {
+            yyjson_mut_val *shot = yyjson_mut_obj_add_arr(doc, err, SHOT_KEY);
+            yyjson_mut_arr_add_uint(doc, shot, match.error.value.shot.row);
+            yyjson_mut_arr_add_uint(doc, shot, match.error.value.shot.column);
+            yyjson_mut_arr_add_uint(doc, shot, match.error.value.shot.value);
+        } break;
+        }
+    }
+}
+
+void BShip_Match_Log_Store(BShip_MatchData match, char *path)
+{
+    assert(path != NULL);
+    assert(match.board_size >= BSHIP_BOARD_SIZE_MIN);
+    assert(match.board_size <= BSHIP_BOARD_SIZE_MAX);
+    assert(match.events.buffer != NULL);
+
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = yyjson_mut_obj(doc);
+    yyjson_mut_doc_set_root(doc, root);
+
+    yyjson_mut_obj_add_uint(doc, root, BOARD_SIZE_KEY, match.board_size);
+    yyjson_mut_val *ai1 = yyjson_mut_obj_add_obj(doc, root, AI1_KEY);
+    yyjson_mut_val *ai2 = yyjson_mut_obj_add_obj(doc, root, AI2_KEY);
+
+    BShip_AIMatchData_Create(doc, ai1, match.ai1);
+    BShip_AIMatchData_Create(doc, ai2, match.ai2);
+
+    yyjson_mut_val *events = yyjson_mut_obj_add_arr(doc, root, EVENTS_KEY);
+    for (size_t i = 0; i < match.events.length; i++)
+    {
+        BShip_Event e = match.events.buffer[i];
+        if (e.type == BSHIP_EVENT_NONE) continue;
+        yyjson_mut_val *event = yyjson_mut_arr_add_arr(doc, events);
+        yyjson_mut_arr_add_uint(doc, event, e.type);
+        switch (e.type)
+        {
+        case BSHIP_EVENT_NONE:
+        case BSHIP_EVENT_GAME_START:
+            break;
+        case BSHIP_EVENT_SHIP_PLACEMENT:
+            yyjson_mut_arr_add_uint(doc, event, e.value.compact.ai1_ship);
+            yyjson_mut_arr_add_uint(doc, event, e.value.compact.ai2_ship);
+            break;
+        case BSHIP_EVENT_SHOT_RESULT:
+            yyjson_mut_arr_add_uint(doc, event, e.value.compact.ai1_shot);
+            yyjson_mut_arr_add_uint(doc, event, e.value.compact.ai2_shot);
+            if (e.value.compact.ai1_ship != 0 || e.value.compact.ai2_ship != 0)
+            {
+                yyjson_mut_arr_add_uint(doc, event, e.value.compact.ai1_ship);
+                yyjson_mut_arr_add_uint(doc, event, e.value.compact.ai2_ship);
+            }
+            break;
+        case BSHIP_EVENT_GAME_RESULT:
+            yyjson_mut_arr_add_uint(doc, event, e.value.ai1_game_result);
+            break;
+        }
+    }
+
+    size_t length = 0;
+    char *json = yyjson_mut_write(doc, 0, &length);
+
+    BShip_Buffer buffer = {
+        .buffer = (uint8_t *)json,
+        .length = length,
+        .capacity = length,
+    };
+
+    BShip_File_Write(path, &buffer);
+
+    free(buffer.buffer);
+    yyjson_mut_doc_free(doc);
+}
+
+bool BShip_AIMatchData_Parse(BShip_Arena *arena, yyjson_val *ai_root, BShip_AIMatchData *match)
+{
+    assert(arena != NULL);
+    assert(match != NULL);
+    assert(match->name != NULL);
+    assert(match->authors != NULL);
+    {
+        yyjson_val *obj = yyjson_obj_get(ai_root, AI_NAME_KEY);
+        if (!yyjson_is_str(obj)) goto on_error;
+        size_t name_len = yyjson_get_len(obj);
+        if (name_len > BSHIP_MESSAGE_NAME_SIZE_MAX)
+        {
+            name_len = BSHIP_MESSAGE_NAME_SIZE_MAX;
+        }
+        const char *name = yyjson_get_str(obj);
+        strncpy(match->name, name, name_len);
+    }
+    {
+        yyjson_val *obj = yyjson_obj_get(ai_root, AUTHOR_NAMES_KEY);
+        if (!yyjson_is_str(obj)) goto on_error;
+        size_t authors_len = yyjson_get_len(obj);
+        if (authors_len > BSHIP_MESSAGE_NAME_SIZE_MAX)
+        {
+            authors_len = BSHIP_MESSAGE_NAME_SIZE_MAX;
+        }
+        const char *authors = yyjson_get_str(obj);
+        strncpy(match->authors, authors, authors_len);
+    }
+
+    yyjson_val *err_obj = yyjson_obj_get(ai_root, ERROR_KEY);
+    match->error.type = ERROR_SUCCESS;
+    if (err_obj != NULL)
+    {
+        if (!yyjson_is_obj(err_obj)) goto on_error;
+        {
+            yyjson_val *obj = yyjson_obj_get(err_obj, ERROR_TYPE_KEY);
+            if (!yyjson_is_uint(obj)) goto on_error;
+            match->error.type = (BShip_ErrorType)yyjson_get_uint(obj);
+        }
+        {
+            yyjson_val *obj = yyjson_obj_get(err_obj, EXIT_STATUS_KEY);
+            if (!yyjson_is_sint(obj)) goto on_error;
+            match->error.exit_status = yyjson_get_sint(obj);
+        }
+        switch (match->error.type)
+        {
+        case ERROR_SUCCESS:
+        case ERROR_AI_PATH_ISSUE:
+        case ERROR_PROCESS_FAILED:
+        case ERROR_CONNECTION_FAILED:
+        case ERROR_CONNECTION_TIMEOUT:
+        case ERROR_SEND_FAILED:
+        case ERROR_SEND_TIMEOUT:
+        case ERROR_RECEIVE_FAILED:
+        case ERROR_RECEIVE_TIMEOUT:
+        case ERROR_RECEIVE_EMPTY_MESSAGE:
+            break;
+        case ERROR_MESSAGE_HELLO_INVALID:
+        case ERROR_MESSAGE_SHIPS_PLACED_INVALID:
+        case ERROR_MESSAGE_SHOT_TAKEN_INVALID:
+        {
+            yyjson_val *obj = yyjson_obj_get(err_obj, MESSAGE_KEY);
+            if (!yyjson_is_str(obj)) goto on_error;
+            size_t message_len = yyjson_get_len(obj);
+            if (message_len > BSHIP_MESSAGE_SIZE)
+            {
+                message_len = BSHIP_MESSAGE_SIZE;
+            }
+            match->error.value.message.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, char, BSHIP_MESSAGE_SIZE);
+            if (match->error.value.message.buffer == NULL) goto on_error;
+            memset(match->error.value.message.buffer, 0, BSHIP_MESSAGE_SIZE);
+            const char *message = yyjson_get_str(obj);
+            strncpy(match->error.value.message.buffer, message, message_len);
+        } break;
+        case ERROR_SHIP_LENGTH_INVALID:
+        case ERROR_SHIP_OFF_BOARD:
+        case ERROR_SHIP_OVERLAP:
+        {
+            yyjson_val *obj = yyjson_obj_get(err_obj, SHIP_KEY);
+            if (!yyjson_is_arr(obj)) goto on_error;
+            if (yyjson_arr_size(obj) != 4) goto on_error;
+            
+            yyjson_val *row = yyjson_arr_get(obj, 0);
+            if (!yyjson_is_uint(row)) goto on_error;
+            match->error.value.ship.row = yyjson_get_uint(row);
+            
+            yyjson_val *column = yyjson_arr_get(obj, 1);
+            if (!yyjson_is_uint(column)) goto on_error;
+            match->error.value.ship.column = yyjson_get_uint(column);
+            
+            yyjson_val *length = yyjson_arr_get(obj, 2);
+            if (!yyjson_is_uint(length)) goto on_error;
+            match->error.value.ship.length = yyjson_get_uint(length);
+            
+            yyjson_val *direction = yyjson_arr_get(obj, 3);
+            if (!yyjson_is_uint(direction)) goto on_error;
+            match->error.value.ship.direction = (BShip_Direction)yyjson_get_uint(direction);
+        } break;
+        case ERROR_SHOT_OFF_BOARD:
+        case ERROR_SHOT_DUPLICATE:
+        {
+            yyjson_val *obj = yyjson_obj_get(err_obj, SHOT_KEY);
+            if (!yyjson_is_arr(obj)) goto on_error;
+            if (yyjson_arr_size(obj) != 3) goto on_error;
+            
+            yyjson_val *row = yyjson_arr_get(obj, 0);
+            if (!yyjson_is_uint(row)) goto on_error;
+            match->error.value.shot.row = yyjson_get_uint(row);
+            
+            yyjson_val *column = yyjson_arr_get(obj, 1);
+            if (!yyjson_is_uint(column)) goto on_error;
+            match->error.value.shot.column = yyjson_get_uint(column);
+            
+            yyjson_val *value = yyjson_arr_get(obj, 2);
+            if (!yyjson_is_uint(value)) goto on_error;
+            match->error.value.shot.value = (BShip_BoardValue)yyjson_get_uint(value);
+        } break;
+        }
+    }
+
+    return true;
+on_error:
+    return false;
+}
+
+bool BShip_Match_Log_Load(BShip_Arena *arena, BShip_MatchData *match, char *path)
+{
+    assert(arena != NULL);
+    assert(match != NULL);
+    assert(path != NULL);
+    ssize_t file_size = BShip_File_GetSize(path);
+    if (file_size == -1)
+    {
+        PRINT_ERROR_F("Match log not found at %s", path);
+        return false;
+    }
+
+    BSHIP_ARENA_TEMP_BEGIN(arena);
+
+    BShip_Buffer buffer = {
+        .buffer = BSHIP_ARENA_PUSH_ARRAY(arena, uint8_t, file_size),
+        .capacity = file_size,
+    };
+
+    if (!BShip_File_Read(path, &buffer, file_size)) return false;
+
+    yyjson_doc *doc = yyjson_read((const char *)buffer.buffer, buffer.length, 0);
+    if (doc == NULL) goto on_error;
+    BSHIP_ARENA_TEMP_END(arena);
+    {
+        match->ai1.name = BSHIP_ARENA_PUSH_ARRAY(arena, char, BSHIP_MESSAGE_NAME_SIZE_MAX);
+        match->ai1.authors = BSHIP_ARENA_PUSH_ARRAY(arena, char, BSHIP_MESSAGE_NAME_SIZE_MAX);
+        if (match->ai1.name == NULL || match->ai1.authors == NULL)
+        {
+            goto on_error;
+        }
+        memset(match->ai1.name, 0, BSHIP_MESSAGE_NAME_SIZE_MAX);
+        memset(match->ai1.authors, 0, BSHIP_MESSAGE_NAME_SIZE_MAX);
+    }
+    {
+        match->ai2.name = BSHIP_ARENA_PUSH_ARRAY(arena, char, BSHIP_MESSAGE_NAME_SIZE_MAX);
+        match->ai2.authors = BSHIP_ARENA_PUSH_ARRAY(arena, char, BSHIP_MESSAGE_NAME_SIZE_MAX);
+        if (match->ai2.name == NULL || match->ai2.authors == NULL)
+        {
+            goto on_error;
+        }
+        memset(match->ai2.name, 0, BSHIP_MESSAGE_NAME_SIZE_MAX);
+        memset(match->ai2.authors, 0, BSHIP_MESSAGE_NAME_SIZE_MAX);
+    }
+
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    {
+        yyjson_val *obj = yyjson_obj_get(root, BOARD_SIZE_KEY);
+        if (!yyjson_is_uint(obj)) goto on_error;
+        match->board_size = yyjson_get_uint(obj);
+    }
+    if (match->board_size < BSHIP_BOARD_SIZE_MIN || match->board_size > BSHIP_BOARD_SIZE_MAX) goto on_error;
+    {
+        yyjson_val *obj = yyjson_obj_get(root, AI1_KEY);
+        if (!yyjson_is_obj(obj)) goto on_error;
+        if (!BShip_AIMatchData_Parse(arena, obj, &match->ai1)) goto on_error;
+    }
+    {
+        yyjson_val *obj = yyjson_obj_get(root, AI2_KEY);
+        if (!yyjson_is_obj(obj)) goto on_error;
+        if (!BShip_AIMatchData_Parse(arena, obj, &match->ai2)) goto on_error;
+    }
+
+    uint32_t games_per_match_max = BShip_GamesPerMatchMax_From_BoardSize(match->board_size);
+    match->game_indexes.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, uint32_t, games_per_match_max);
+    if (match->game_indexes.buffer == NULL) goto on_error;
+    match->game_indexes.capacity = games_per_match_max;
+
+    yyjson_val *events = yyjson_obj_get(root, EVENTS_KEY);
+    if (!yyjson_is_arr(events)) goto on_error;
+
+    size_t events_size = yyjson_arr_size(events);
+    match->events.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, BShip_Event, events_size);
+    if (match->events.buffer == NULL) goto on_error;
+    match->events.capacity = events_size;
+
+    for (size_t i = 0; i < events_size; i++)
+    {
+        yyjson_val *event = yyjson_arr_get(events, i);
+        if (!yyjson_is_arr(event)) goto on_error;
+        size_t event_size = yyjson_arr_size(event);
+        if (event_size == 0 || event_size > 5) goto on_error;
+        
+        yyjson_val *event_type = yyjson_arr_get(event, 0);
+        if (!yyjson_is_uint(event_type)) goto on_error;
+        BShip_Event e = {
+            .type = (BShip_EventType)yyjson_get_uint(event_type),
+        };
+        switch (e.type)
+        {
+        case BSHIP_EVENT_NONE:
+        case BSHIP_EVENT_GAME_START:
+            break;
+        case BSHIP_EVENT_SHIP_PLACEMENT:
+        {
+            if (event_size != 3) goto on_error;
+            yyjson_val *ai1_ship = yyjson_arr_get(event, 1);
+            if (!yyjson_is_uint(ai1_ship)) goto on_error;
+            e.value.compact.ai1_ship = yyjson_get_uint(ai1_ship);
+
+            yyjson_val *ai2_ship = yyjson_arr_get(event, 2);
+            if (!yyjson_is_uint(ai2_ship)) goto on_error;
+            e.value.compact.ai2_ship = yyjson_get_uint(ai2_ship);
+        } break;
+        case BSHIP_EVENT_SHOT_RESULT:
+        {
+            if (event_size != 3 && event_size != 5) goto on_error;
+            yyjson_val *ai1_shot = yyjson_arr_get(event, 1);
+            if (!yyjson_is_uint(ai1_shot)) goto on_error;
+            e.value.compact.ai1_shot = yyjson_get_uint(ai1_shot);
+
+            yyjson_val *ai2_shot = yyjson_arr_get(event, 2);
+            if (!yyjson_is_uint(ai2_shot)) goto on_error;
+            e.value.compact.ai2_shot = yyjson_get_uint(ai2_shot);
+
+            if (event_size == 5)
+            {
+                yyjson_val *ai1_ship = yyjson_arr_get(event, 3);
+                if (!yyjson_is_uint(ai1_ship)) goto on_error;
+                e.value.compact.ai1_ship = yyjson_get_uint(ai1_ship);
+
+                yyjson_val *ai2_ship = yyjson_arr_get(event, 4);
+                if (!yyjson_is_uint(ai2_ship)) goto on_error;
+                e.value.compact.ai2_ship = yyjson_get_uint(ai2_ship);
+            }
+        } break;
+        case BSHIP_EVENT_GAME_RESULT:
+        {
+            if (event_size != 2) goto on_error;
+
+            yyjson_val *game_result = yyjson_arr_get(event, 1);
+            if (!yyjson_is_uint(game_result)) goto on_error;
+            e.value.ai1_game_result = (BShip_GameResult)yyjson_get_uint(game_result);
+
+        } break;
+        }
+        if (e.type == BSHIP_EVENT_GAME_START)
+        {
+            BShip_U32Array_Push(&match->game_indexes, match->events.length);
+        }
+        BShip_EventArray_Push(&match->events, e);
+    }
+
+
+    yyjson_doc_free(doc);
+    return true;
+on_error:
+    PRINT_ERROR_F("Invalid match log stored at %s", path);
+    yyjson_doc_free(doc);
+    return false;
+}

--- a/lib/platforms/platform.h
+++ b/lib/platforms/platform.h
@@ -15,9 +15,17 @@ void *BShip_Allocate(size_t size);
 
 void BShip_Deallocate(void *ptr);
 
+bool BShip_PathIsFile(char *path);
+
 bool BShip_PathIsExecutable(char *path);
 
 bool BShip_PathIsDirectory(char *path);
+
+ssize_t BShip_File_GetSize(char *path);
+
+bool BShip_File_Read(char *path, BShip_Buffer *buffer, size_t size);
+
+bool BShip_File_Write(char *path, BShip_Buffer *buffer);
 
 typedef struct BShip_Connection BShip_Connection;
 

--- a/lib/platforms/unix.c
+++ b/lib/platforms/unix.c
@@ -58,6 +58,17 @@ void BShip_Deallocate(void *ptr)
     }
 }
 
+bool BShip_PathIsFile(char *path)
+{
+    struct stat statbuf = {0};
+    if (stat(path, &statbuf) == -1)
+    {
+        PRINT_ERROR(strerror(errno));
+        return false;
+    }
+    return S_ISREG(statbuf.st_mode);
+}
+
 bool BShip_PathIsExecutable(char *path)
 {
     struct stat statbuf = {0};
@@ -78,6 +89,70 @@ bool BShip_PathIsDirectory(char *path)
         return false;
     }
     return (S_ISDIR(statbuf.st_mode));
+}
+
+ssize_t BShip_File_GetSize(char *path)
+{
+    struct stat statbuf = {0};
+    if (stat(path, &statbuf) == -1)
+    {
+        PRINT_ERROR(strerror(errno));
+        return -1;
+    }
+    if (!S_ISREG(statbuf.st_mode))
+    {
+        return -1;
+    }
+    return statbuf.st_size;
+}
+
+bool BShip_File_Read(char *path, BShip_Buffer *buffer, size_t size)
+{
+    assert(size <= buffer->capacity);
+    int fd = open(path, O_RDONLY);
+    if (fd == -1)
+    {
+        PRINT_ERROR(strerror(errno));
+        goto on_error;
+    }
+
+    ssize_t count = read(fd, buffer->buffer, size);
+    if (count == -1)
+    {
+        PRINT_ERROR(strerror(errno));
+        buffer->length = 0;
+        goto on_error;
+    }
+    buffer->length = count;
+
+    close(fd);
+    return true;
+on_error:
+    if (fd != -1) close(fd);
+    return false;
+}
+
+bool BShip_File_Write(char *path, BShip_Buffer *buffer)
+{
+    int fd = open(path, O_CREAT|O_RDWR|O_TRUNC, 0664);
+    if (fd == -1)
+    {
+        PRINT_ERROR(strerror(errno));
+        goto on_error;
+    }
+
+    ssize_t count = write(fd, buffer->buffer, buffer->length);
+    if (count == -1)
+    {
+        PRINT_ERROR(strerror(errno));
+        goto on_error;
+    }
+
+    close(fd);
+    return true;
+on_error:
+    if (fd != -1) close(fd);
+    return false;
 }
 
 size_t BShip_Connection_GetSize(void)

--- a/lib/runtime.c
+++ b/lib/runtime.c
@@ -10,13 +10,47 @@
 
 #include "arena.c"
 #include "message.c"
+#include "log.c"
 #include "game.c"
 #include "contest.c"
 
-BSHIP_DEFINE_ARRAY_PUSH(BShip_ShipArray, BShip_Ship)
-BSHIP_DEFINE_ARRAY_PUSH(BShip_ShotArray, BShip_Shot)
-BSHIP_DEFINE_ARRAY_PUSH(BShip_EventArray, BShip_Event)
-BSHIP_DEFINE_ARRAY_PUSH(BShip_U32Array, uint32_t)
+BShip_CompactShip BShip_CompactShip_From_Ship(BShip_Ship ship)
+{
+    BShip_CompactShip compact = ship.row;
+    compact |= (ship.column << 4);
+    compact |= (ship.length << 8);
+    compact |= (ship.direction << 12);
+    return compact;
+}
+
+BShip_Ship BShip_Ship_From_CompactShip(BShip_CompactShip compact)
+{
+    BShip_Ship ship = {
+        .row = compact & 0xF,
+        .column = (compact >> 4) & 0xF,
+        .length = (compact >> 8) & 0xF,
+        .direction = (BShip_Direction)(compact >> 12) & 0xF,
+    };
+    return ship;
+}
+
+BShip_CompactShot BShip_CompactShot_From_Shot(BShip_Shot shot)
+{
+    BShip_CompactShot compact = shot.row;
+    compact |= (shot.column << 4);
+    compact |= (shot.value << 8);
+    return compact;
+}
+
+BShip_Shot BShip_Shot_From_CompactShot(BShip_CompactShot compact)
+{
+    BShip_Shot shot = {
+        .row = compact & 0xF,
+        .column = (compact >> 4) & 0xF,
+        .value = (BShip_BoardValue)(compact >> 8) & 0xF,
+    };
+    return shot;
+}
 
 size_t BShip_Game_CalculateMemorySize(uint8_t board_size)
 {
@@ -52,7 +86,6 @@ bool BShip_Game_Run(BShip_Arena *arena, BShip_Connection *conn,
         BShip_ShipArray ships;
         BShip_U8Array alive_ships;
         BShip_U8Array dead_ships;
-        uint32_t ship_index_start;
     } BShip_AIGameState;
 
     BShip_AIGameState ai1 = {
@@ -68,7 +101,6 @@ bool BShip_Game_Run(BShip_Arena *arena, BShip_Connection *conn,
             .buffer = BSHIP_ARENA_PUSH_ARRAY(arena, uint8_t, ship_count_max),
             .capacity = ship_count_max,
         },
-        .ship_index_start = match->ai1.ships.length,
     };
 
     BShip_AIGameState ai2 = {
@@ -84,7 +116,6 @@ bool BShip_Game_Run(BShip_Arena *arena, BShip_Connection *conn,
             .buffer = BSHIP_ARENA_PUSH_ARRAY(arena, uint8_t, ship_count_max),
             .capacity = ship_count_max,
         },
-        .ship_index_start = match->ai2.ships.length,
     };
     if (ai1.ships.buffer == NULL || ai1.alive_ships.buffer == NULL || ai1.dead_ships.buffer == NULL ||
         ai2.ships.buffer == NULL || ai2.alive_ships.buffer == NULL || ai2.dead_ships.buffer == NULL)
@@ -167,13 +198,10 @@ bool BShip_Game_Run(BShip_Arena *arena, BShip_Connection *conn,
 
         BShip_Event ship_place_event = {
             .type = BSHIP_EVENT_SHIP_PLACEMENT,
-            .value.indexes.ai1_ship_index = match->ai1.ships.length,
-            .value.indexes.ai2_ship_index = match->ai2.ships.length,
+            .value.compact.ai1_ship = BShip_CompactShip_From_Ship(ai1.ships.buffer[i]),
+            .value.compact.ai2_ship = BShip_CompactShip_From_Ship(ai2.ships.buffer[i]),
         };
         BShip_EventArray_Push(&match->events, ship_place_event);
-
-        BShip_ShipArray_Push(&match->ai1.ships, ai1.ships.buffer[i]);
-        BShip_ShipArray_Push(&match->ai2.ships, ai2.ships.buffer[i]);
     }
 
     bool next_shot = true;
@@ -222,15 +250,14 @@ bool BShip_Game_Run(BShip_Arena *arena, BShip_Connection *conn,
 
         BShip_Event shot_result_event = {
             .type = BSHIP_EVENT_SHOT_RESULT,
-            .value.indexes.ai1_ship_index = ai1_ship_dead ? ai1.ship_index_start + ai1_dead_ship_index : 0,
-            .value.indexes.ai2_ship_index = ai2_ship_dead ? ai2.ship_index_start + ai2_dead_ship_index : 0,
-            .value.indexes.ai1_shot_index = match->ai1.shots.length,
-            .value.indexes.ai2_shot_index = match->ai2.shots.length,
+            .value.compact.ai1_shot = BShip_CompactShot_From_Shot(ai1_shot),
+            .value.compact.ai2_shot = BShip_CompactShot_From_Shot(ai2_shot),
+            .value.compact.ai1_ship = ai1_ship_dead ?
+                BShip_CompactShip_From_Ship(ai1.ships.buffer[ai1_dead_ship_index]) : 0,
+            .value.compact.ai2_ship = ai2_ship_dead ?
+                BShip_CompactShip_From_Ship(ai2.ships.buffer[ai2_dead_ship_index]) : 0,
         };
         BShip_EventArray_Push(&match->events, shot_result_event);
-
-        BShip_ShotArray_Push(&match->ai1.shots, ai1_shot);
-        BShip_ShotArray_Push(&match->ai2.shots, ai2_shot);
 
         if (ai1.alive_ships.length == 0 || ai2.alive_ships.length == 0)
         {
@@ -301,7 +328,6 @@ size_t BShip_Match_CalculateMemorySize(uint8_t board_size, uint32_t games_per_ma
     size_t shot_count_max = board_size * board_size * games_per_match;
     size_t game_temp_mem_size = BShip_Game_CalculateMemorySize(board_size);
     size_t per_ai_mem_size = (BSHIP_MESSAGE_NAME_SIZE_MAX * 4) + (BSHIP_MESSAGE_SIZE * 2)
-        + (sizeof(BShip_Ship) * (ship_count_max+1)) + (sizeof(BShip_Shot) * (shot_count_max+1))
         + BShip_AIConnection_GetSize();
     return game_temp_mem_size + (per_ai_mem_size * 2) + BShip_Connection_GetSize() +
         (sizeof(uint32_t) * games_per_match) +
@@ -366,42 +392,14 @@ BShip_MatchData BShip_Match_Run(BShip_Arena *arena, char *socket_path,
         memset(match.ai2.name, 0, BSHIP_MESSAGE_NAME_SIZE_MAX);
         memset(match.ai2.authors, 0, BSHIP_MESSAGE_NAME_SIZE_MAX);
     }
-    uint32_t ship_count_max = ShipCountMax_From_BoardSize(match.board_size) * match.games_per_match;
-    {
-        uint32_t ships_capacity = ship_count_max+1;
-        match.ai1.ships.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, BShip_Ship, ships_capacity);
-        match.ai1.ships.capacity = ships_capacity;
-        match.ai2.ships.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, BShip_Ship, ships_capacity);
-        match.ai2.ships.capacity = ships_capacity;
-        if (match.ai1.ships.buffer == NULL || match.ai2.ships.buffer == NULL)
-        {
-            return match;
-        }
-        BShip_Ship empty_ship = {0};
-        BShip_ShipArray_Push(&match.ai1.ships, empty_ship);
-        BShip_ShipArray_Push(&match.ai2.ships, empty_ship);
-    }
-    uint32_t shot_count_max = match.board_size * match.board_size * match.games_per_match;
-    {
-        uint32_t shots_capacity = shot_count_max+1;
-        match.ai1.shots.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, BShip_Shot, shots_capacity);
-        match.ai1.shots.capacity = shots_capacity;
-        match.ai2.shots.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, BShip_Shot, shots_capacity);
-        match.ai2.shots.capacity = shots_capacity;
-        if (match.ai1.shots.buffer == NULL || match.ai2.shots.buffer == NULL)
-        {
-            return match;
-        }
-        BShip_Shot empty_shot = {0};
-        BShip_ShotArray_Push(&match.ai1.shots, empty_shot);
-        BShip_ShotArray_Push(&match.ai2.shots, empty_shot);
-    }
     match.game_indexes.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, uint32_t, match.games_per_match);
     match.game_indexes.capacity = match.games_per_match;
     if (match.game_indexes.buffer == NULL)
     {
         return match;
     }
+    uint32_t ship_count_max = ShipCountMax_From_BoardSize(match.board_size) * match.games_per_match;
+    uint32_t shot_count_max = match.board_size * match.board_size * match.games_per_match;
     uint32_t events_max = ship_count_max + shot_count_max + (match.games_per_match * 2);
     match.events.buffer = BSHIP_ARENA_PUSH_ARRAY(arena, BShip_Event, events_max);
     match.events.capacity = events_max;
@@ -457,6 +455,10 @@ BShip_MatchData BShip_Match_Run(BShip_Arena *arena, char *socket_path,
     {
         goto on_conn_accept_error;
     }
+    match.ai1.ai_name_length = strlen(match.ai1.name);
+    match.ai2.ai_name_length = strlen(match.ai2.name);
+    match.ai1.author_name_length = strlen(match.ai1.authors);
+    match.ai2.author_name_length = strlen(match.ai2.authors);
 
     BShip_Message_SetupMatch_Create(&ai1_message, match.board_size, BSHIP_PLAYER_1);
     BShip_Message_SetupMatch_Create(&ai2_message, match.board_size, BSHIP_PLAYER_2);

--- a/lib/runtime.c
+++ b/lib/runtime.c
@@ -462,10 +462,10 @@ BShip_MatchData BShip_Match_Run(BShip_Arena *arena, char *socket_path,
     {
         goto on_conn_accept_error;
     }
-    match.ai1.ai_name_length = strlen(match.ai1.name);
-    match.ai2.ai_name_length = strlen(match.ai2.name);
-    match.ai1.author_name_length = strlen(match.ai1.authors);
-    match.ai2.author_name_length = strlen(match.ai2.authors);
+    match.ai1.ai_name_length = strnlen(match.ai1.name, BSHIP_MESSAGE_NAME_SIZE_MAX);
+    match.ai2.ai_name_length = strnlen(match.ai2.name, BSHIP_MESSAGE_NAME_SIZE_MAX);
+    match.ai1.author_name_length = strnlen(match.ai1.authors, BSHIP_MESSAGE_NAME_SIZE_MAX);
+    match.ai2.author_name_length = strnlen(match.ai2.authors, BSHIP_MESSAGE_NAME_SIZE_MAX);
 
     BShip_Message_SetupMatch_Create(&ai1_message, match.board_size, BSHIP_PLAYER_1);
     BShip_Message_SetupMatch_Create(&ai2_message, match.board_size, BSHIP_PLAYER_2);

--- a/lib/runtime.c
+++ b/lib/runtime.c
@@ -16,10 +16,14 @@
 
 BShip_CompactShip BShip_CompactShip_From_Ship(BShip_Ship ship)
 {
-    BShip_CompactShip compact = ship.row;
-    compact |= (ship.column << 4);
-    compact |= (ship.length << 8);
-    compact |= (ship.direction << 12);
+    assert(ship.row <= 0xF);
+    assert(ship.column <= 0xF);
+    assert(ship.length <= 0x7);
+    assert(ship.direction <= 0x1);
+    BShip_CompactShip compact = ship.row & 0xF;
+    compact |= ((ship.column & 0xF) << 4);
+    compact |= ((ship.length & 0x7) << 8);
+    compact |= ((ship.direction & 0x1) << 11);
     return compact;
 }
 
@@ -28,17 +32,20 @@ BShip_Ship BShip_Ship_From_CompactShip(BShip_CompactShip compact)
     BShip_Ship ship = {
         .row = compact & 0xF,
         .column = (compact >> 4) & 0xF,
-        .length = (compact >> 8) & 0xF,
-        .direction = (BShip_Direction)(compact >> 12) & 0xF,
+        .length = (compact >> 8) & 0x7,
+        .direction = (BShip_Direction)(compact >> 11) & 0x1,
     };
     return ship;
 }
 
 BShip_CompactShot BShip_CompactShot_From_Shot(BShip_Shot shot)
 {
-    BShip_CompactShot compact = shot.row;
-    compact |= (shot.column << 4);
-    compact |= (shot.value << 8);
+    assert(shot.row <= 0xF);
+    assert(shot.column <= 0xF);
+    assert(shot.value <= 0xF);
+    BShip_CompactShot compact = shot.row & 0xF;
+    compact |= ((shot.column & 0xF) << 4);
+    compact |= ((shot.value & 0xF) << 8);
     return compact;
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -181,6 +181,7 @@ vector<BShip_AIFileData> GetAIs(BShip_Arena *arena)
 
 int main(void)
 {
+    char *log_file_path = (char *)"./logs/new_match_log.json";
     bool debug = true;
     BShip_Arena string_arena = {};
     BShip_Arena_Initialize(&string_arena, 0); // 0 creates default size.
@@ -201,6 +202,21 @@ int main(void)
 
         BShip_MatchData match = BShip_Match_Run(&arena, (char *)"/tmp/battleships.sock",
             options.ai1, options.ai2, options.board_size, options.games_per_match, debug);
+
+        BShip_Match_Log_Store(match, log_file_path);
+
+        TUI_Match_Display(match, options.match_display_type,
+            options.step_delay_ms, options.manual_stepping, debug);
+
+        BShip_Arena_Destroy(&arena);
+    }
+    else if (options.runtime == RUNTIME_REPLAY_MATCH)
+    {
+        BShip_Arena arena = {};
+        BShip_Arena_Initialize(&arena, 0);
+        BShip_MatchData match = {};
+
+        BShip_Match_Log_Load(&arena, &match, log_file_path);
 
         TUI_Match_Display(match, options.match_display_type,
             options.step_delay_ms, options.manual_stepping, debug);

--- a/src/tui/results.cpp
+++ b/src/tui/results.cpp
@@ -294,32 +294,26 @@ void TUI_GameStepState_Apply(TUI_GameStepState *state, BShip_MatchData match,
         BShip_Event event = match.events.buffer[i];
         if (event.type == BSHIP_EVENT_SHIP_PLACEMENT)
         {
-            assert(event.value.indexes.ai1_ship_index < match.ai1.ships.length);
-            assert(event.value.indexes.ai2_ship_index < match.ai2.ships.length);
-            BShip_Ship ai1_ship = match.ai1.ships.buffer[event.value.indexes.ai1_ship_index];
-            BShip_Ship ai2_ship = match.ai2.ships.buffer[event.value.indexes.ai2_ship_index];
+            BShip_Ship ai1_ship = BShip_Ship_From_CompactShip(event.value.compact.ai1_ship);
+            BShip_Ship ai2_ship = BShip_Ship_From_CompactShip(event.value.compact.ai2_ship);
             TUI_Store_Ship(ai1_board, ai1_ship, BSHIP_SHIP);
             TUI_Store_Ship(ai2_board, ai2_ship, BSHIP_SHIP);
         }
         else if (event.type == BSHIP_EVENT_SHOT_RESULT)
         {
-            assert(event.value.indexes.ai1_shot_index < match.ai1.shots.length);
-            assert(event.value.indexes.ai2_shot_index < match.ai2.shots.length);
-            BShip_Shot ai1_shot = match.ai1.shots.buffer[event.value.indexes.ai1_shot_index];
-            BShip_Shot ai2_shot = match.ai2.shots.buffer[event.value.indexes.ai2_shot_index];
+            BShip_Shot ai1_shot = BShip_Shot_From_CompactShot(event.value.compact.ai1_shot);
+            BShip_Shot ai2_shot = BShip_Shot_From_CompactShot(event.value.compact.ai2_shot);
             BShip_Board_Set(ai1_board, ai2_shot.row, ai2_shot.column, ai2_shot.value);
             BShip_Board_Set(ai2_board, ai1_shot.row, ai1_shot.column, ai1_shot.value);
 
-            if (event.value.indexes.ai1_ship_index > 0)
+            if (event.value.compact.ai1_ship > 0)
             {
-                assert(event.value.indexes.ai1_ship_index < match.ai1.ships.length);
-                BShip_Ship ai1_dead_ship = match.ai1.ships.buffer[event.value.indexes.ai1_ship_index];
+                BShip_Ship ai1_dead_ship = BShip_Ship_From_CompactShip(event.value.compact.ai1_ship);
                 TUI_Store_Ship(ai1_board, ai1_dead_ship, BSHIP_KILL);
             }
-            if (event.value.indexes.ai2_ship_index > 0)
+            if (event.value.compact.ai2_ship > 0)
             {
-                assert(event.value.indexes.ai2_ship_index < match.ai2.ships.length);
-                BShip_Ship ai2_dead_ship = match.ai2.ships.buffer[event.value.indexes.ai2_ship_index];
+                BShip_Ship ai2_dead_ship = BShip_Ship_From_CompactShip(event.value.compact.ai2_ship);
                 TUI_Store_Ship(ai2_board, ai2_dead_ship, BSHIP_KILL);
             }
         }
@@ -430,25 +424,21 @@ void TUI_TextGroups_Add_EventDescriptions(vector<TUI_TextGroup> &ai1_group, vect
     case BSHIP_EVENT_SHIP_PLACEMENT:
         ai1_group.push_back(TUI_TextGroup_Default(TUI_Text_Default("")));
         ai2_group.push_back(TUI_TextGroup_Default(TUI_Text_Default("")));
-        assert(event.value.indexes.ai1_ship_index < match.ai1.ships.length);
-        assert(event.value.indexes.ai2_ship_index < match.ai2.ships.length);
-        ai1_ship = match.ai1.ships.buffer[event.value.indexes.ai1_ship_index];
-        ai2_ship = match.ai2.ships.buffer[event.value.indexes.ai2_ship_index];
+        ai1_ship = BShip_Ship_From_CompactShip(event.value.compact.ai1_ship);
+        ai2_ship = BShip_Ship_From_CompactShip(event.value.compact.ai2_ship);
         ai1_group.push_back(TUI_TextGroup_Make_ShipPlacementEvent(ai1_ship, BSHIP_PLAYER_1));
         ai2_group.push_back(TUI_TextGroup_Make_ShipPlacementEvent(ai2_ship, BSHIP_PLAYER_2));
         break;
     case BSHIP_EVENT_SHOT_RESULT:
         ai1_group.push_back(TUI_TextGroup_Default(TUI_Text_Default("")));
         ai2_group.push_back(TUI_TextGroup_Default(TUI_Text_Default("")));
-        assert(event.value.indexes.ai1_shot_index < match.ai1.shots.length);
-        assert(event.value.indexes.ai2_shot_index < match.ai2.shots.length);
-        ai1_shot = match.ai1.shots.buffer[event.value.indexes.ai1_shot_index];
-        ai2_shot = match.ai2.shots.buffer[event.value.indexes.ai2_shot_index];
-        if (event.value.indexes.ai1_ship_index > 0)
+        ai1_shot = BShip_Shot_From_CompactShot(event.value.compact.ai1_shot);
+        ai2_shot = BShip_Shot_From_CompactShot(event.value.compact.ai2_shot);
+        if (event.value.compact.ai1_ship > 0)
         {
             ai2_shot.value = BSHIP_KILL;
         }
-        if (event.value.indexes.ai2_ship_index > 0)
+        if (event.value.compact.ai2_ship > 0)
         {
             ai1_shot.value = BSHIP_KILL;
         }
@@ -475,11 +465,6 @@ void TUI_GameStepState_Display(TUI_Window *window, TUI_GameStepState *state, BSh
     size_t board_display_width = 2 + match.board_size;
     size_t name_display_width = ai1_name.size() > ai2_name.size() ? ai1_name.size() : ai2_name.size();
     size_t total_display_width = board_display_width > name_display_width ? board_display_width : name_display_width;
-
-    // size_t board_display_width = match.board_size + 15;
-    // size_t name_display_width = ai1_name.size() + 15;
-    // size_t board2_column_offset = board_display_width > name_display_width
-    //     ? board_display_width : name_display_width;
 
     uint32_t game_index = TUI_GameStepState_GameIndex_Get(state);
     uint32_t game_num = game_index + 1;


### PR DESCRIPTION
Features/improvements:
- Added the ability to store match logs to a JSON document.
- Reduced the size of each event in half by reducing the size of ships/shots and storing them inline instead of storing indexes, which also reduces the runtime memory needs from 2 MB -> 1 MB (for default settings).
- Reduced the size of the logs when compared to the old log sizes.
- Enable replay on match logs.